### PR TITLE
Fix README.md example to import the right tag.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ add the dependency
 
 ```
 dependencies {
-		compile 'com.github.MSF-Jarvis:AppRate:v1.3'
+		compile 'com.github.MSF-Jarvis:AppRate:1.3'
 	}
 ```
 


### PR DESCRIPTION
There is some inconsistencies with the tags. For example, there are two 1.2 - one has the `v` in front and the other one doesn't. `1.3` does not have the `v`.